### PR TITLE
Add support for TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: r
+cache: packages
+warnings_are_errors: false
+
+r:
+  - oldrel
+  - release
+  - devel
+
+r_packages:
+  - argparse
+  - bit64
+  - covr  # for codecov
+  - data.table
+  - doParallel
+  - dplyr
+  - foreach
+  - Hmisc
+  - labelled
+  - plyr
+
+r_check_args: --no-build-vignettes --no-manual --no-codoc --no-examples
+
+after_success:
+  - test $TRAVIS_R_VERSION_STRING = 'release' && Rscript -e 'covr::codecov()'
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # growthcleanr
 
+[![Build Status](https://travis-ci.com/mitre/growthcleanr.svg?branch=main)](https://travis-ci.com/mitre/growthcleanr)
+
 R package for cleaning data from Electronic Health Record systems, focused on
 cleaning height and weight measurements.
 


### PR DESCRIPTION
This should provide sufficient configuration to run regular automated builds on MITRE's main branch, and for any PRs and changes we work on over there. It also adds a Travis badge to the README just for reassurance/fun.

I'm not 100% sure whether any builds will trigger on Carrie's repo without additional configuration w/Travis on that end, though I am expecting they will not. For now, builds can run off MITRE changes and the badge can just represent the build status on the MITRE fork.