### PR TITLE
Switched to argparser, README cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,4 @@ packrat/src/
 *.swp
 output
 .Rproj.user
-
-renv*
+.Rprofile

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
   )
 Maintainer: Robert Grundmeier <grundmeier@email.chop.edu>
 Description: Cleans growth data that may contain implausible data based on unit or data range
-Imports: 
+Imports:
     data.table (>= 1.13.0),
     tidyr (>= 1.1.0),
     plyr (>= 1.8.6),
@@ -27,8 +27,8 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
-Suggests: 
-    argparse (>= 2.0.1),
+Suggests:
+    argparser (>= 0.6),
     bit64 (>= 4.0.2),
     knitr (>= 1.29),
     rmarkdown (>= 2.3),

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY LICENSE /LICENSE
 COPY README.md /README.md
 
 RUN R -e "install.packages(c( \
-    'argparse', \
+    'argparser', \
     'bit64', \
     'data.table', \
     'doParallel', \

--- a/README-adjustcarryforward.md
+++ b/README-adjustcarryforward.md
@@ -28,6 +28,7 @@ file:
 ```R
 > fwrite(cleaned_data, "cleaned.csv", row.names = F)
 ```
+
 Note that the column names should be as described for `cleaned_data` the Example
 under Quickstart.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ following packages:
 * `tidyr`
 * `magrittr`
 
-In addition, an R environment with `devtools` installed is also required. 
+In addition, an R environment with `devtools` installed is also required.
 Further installation details and notes can be found under
 [Installation](#installation) below.
 
@@ -210,7 +210,7 @@ In an up-to-date R environment such as RStudio, first install the dependencies:
 # Required packages for growthcleanr operation
 install.packages("devtools")
 # Optional additional packages referenced in this document
-install.packages("argparse")
+install.packages("argparser")
 install.packages("bit64")
 ```
 
@@ -694,8 +694,9 @@ pitfalls to avoid. The following lays out a rough approach:
 [1] "mydata.00000.csv" "mydata.00001.csv" "mydata.00002.csv" "mydata.00003.csv" "mydata.00004.csv" "mydata.00005.csv"
 ```
 
-* Write a standalone driver script to execute `growthcleanr` on each separate
-  file, then write out its results when complete. An example is below.
+* Use the standalone driver script `exec/gcdriver.R` to execute growthcleanr`
+  on each separate file, then write out its results when complete. An example
+  is below.
 * Invoke the job using a tool like
   [GNU Parallel](https://www.gnu.org/software/parallel/), which can be run on
   all major platforms. An example invocation is below as well.
@@ -703,44 +704,7 @@ pitfalls to avoid. The following lays out a rough approach:
   Then re-run the job on only the remaining input data.
 * When complete, re-combine the data into one file or as otherwise appropriate.
 
-A standalone driver script might look like the following (note that it uses the
-`argparse` library for processing options; this should make it easy to read, but
-requires additional installation steps from what is recommended above under
-[Installation](#installation)).
-
-```R
-library(argparse)
-library(data.table)
-library(growthcleanr)
-
-parser <- ArgumentParser(description='Run cleangrowth() from script')
-parser$add_argument('infile', metavar='INFILE', type="character", nargs=1,
-                    help='input file')
-parser$add_argument('outfile', metavar='OUTFILE', type='character', nargs=1,
-                    help='output file')
-parser$add_argument('--sdrecenter', type='character', nargs=1, default='',
-                    help='sd.recenter data file')
-parser$add_argument('--quietly', default=F, action='store_true',
-                    help='Disable verbose output')
-args <- parser$parse_args()
-
-if (args$sdrecenter != '' ) {
-  sdrecenter <- fread(args$sdrecenter)
-} else {
-  sdrecenter <- ''
-}
-
-df_in <- fread(args$infile)
-df_out <- df_in[, clean_value:=
-                cleangrowth(subjid, param, agedays, sex, measurement,
-                            sd.recenter=sdrecenter,
-                            quietly=args$quietly)
-           ]
-write.csv(df_out, args$outfile, row.names=FALSE)
-```
-
-A file like this could be saved as, for example, `gcdriver.R`, which can then
-be invoked on a single input file using `Rscript`:
+To invoke `gcdriver.R` on a single input file using `Rscript`:
 
 ```bash
 % Rscript gcdriver.R --quietly --sdrecenter sdmedians.csv mydata.csv mydata-cleaned.csv

--- a/exec/gcdriver.R
+++ b/exec/gcdriver.R
@@ -1,57 +1,59 @@
 #!/usr/bin/env Rscript
 
-library(argparse)
+library(argparser)
 library(data.table)
 
 library(growthcleanr)
 
-parser <-
-  ArgumentParser(description = 'CLI driver for growthcleanr')
-parser$add_argument(
-  'infile',
-  metavar = 'INFILE',
+parser <- arg_parser("CLI driver for growthcleanr")
+
+parser <- add_argument(parser,
+  "infile",
   type = "character",
   nargs = 1,
-  help = 'input file'
+  help = "input file"
 )
-parser$add_argument(
-  'outfile',
-  metavar = 'OUTFILE',
-  type = 'character',
+parser <- add_argument(parser,
+  "outfile",
+  type = "character",
   nargs = 1,
-  help = 'output file'
+  help = "output file"
 )
-parser$add_argument(
-  '--sdrecenter',
-  type = 'character',
+parser <- add_argument(
+  parser,
+  "--sdrecenter",
+  type = "character",
   nargs = 1,
-  default = '',
-  help = 'sd.recenter data file'
+  default = "",
+  help = "sd.recenter data file"
 )
-parser$add_argument('--quietly',
-                    default = F,
-                    action = 'store_true',
-                    help = 'Disable verbose output')
-args <- parser$parse_args()
+parser <- add_argument(parser,
+  "--quietly",
+  flag = TRUE,
+  help = "Disable verbose output"
+)
 
-logfile <- sprintf('output/log/log-%s.txt', args$infile)
+argv <- parse_args(parser)
+print(argv)
 
-if (args$sdrecenter != '') {
-  sdrecenter <- fread(args$sdrecenter)
+logfile <- sprintf("output/log/log-%s.txt", argv$infile)
+
+if (argv$sdrecenter != "") {
+  sdrecenter <- fread(argv$sdrecenter)
 } else {
-  sdrecenter <- ''
+  sdrecenter <- ""
 }
 
-df_in <- fread(args$infile)
+df_in <- fread(argv$infile)
 df_out <- df_in[, exclude :=
-                  cleangrowth(
-                    subjid,
-                    param,
-                    agedays,
-                    sex,
-                    measurement,
-                    sd.recenter = sdrecenter,
-                    log.path = logfile,
-                    quietly = args$quietly
-                  )]
-fwrite(df_out, args$outfile, row.names = FALSE)
+  cleangrowth(
+    subjid,
+    param,
+    agedays,
+    sex,
+    measurement,
+    sd.recenter = sdrecenter,
+    log.path = logfile,
+    quietly = argv$quietly
+  )]
+fwrite(df_out, argv$outfile, row.names = FALSE)

--- a/exec/testadjustcf.R
+++ b/exec/testadjustcf.R
@@ -8,7 +8,7 @@
 
 # Specify libraries ----
 
-library(argparse, quietly = T)
+library(argparser, quietly = TRUE)
 # Load plyr before dplyr intentionally
 library(plyr, quietly = T)
 library(dplyr, quietly = T)
@@ -34,24 +34,28 @@ make_grid_vect <- function(low,
                            grid.length,
                            searchtype,
                            is_included = T,
-                           fg_val = (low + high)/2){
-  if (searchtype == "random"){ # random parameter sweep
-    mid <- (low + high)/2
+                           fg_val = (low + high) / 2) {
+  if (searchtype == "random") {
+    # random parameter sweep
+    mid <- (low + high) / 2
     # return half random below, midpoint, half random above
-    gv <- c(runif(floor(grid.length/2), low, mid),
-            mid,
-            runif(floor(grid.length/2), mid, high))
+    gv <- c(
+      runif(floor(grid.length / 2), low, mid),
+      mid,
+      runif(floor(grid.length / 2), mid, high)
+    )
 
     return(gv)
-  } else if (searchtype == "line-grid") { # line-grid parameter sweep
+  } else if (searchtype == "line-grid") {
+    # line-grid parameter sweep
     return(seq(low, high, length = grid.length))
-  } else if (searchtype == "full-grid"){
-    if (is_included){
+  } else if (searchtype == "full-grid") {
+    if (is_included) {
       # full grid vectors are put together outside the list
       return(seq(low, high, length = grid.length))
     } else {
-      if (is.na(fg_val)){
-        return(c((low + high)/2))
+      if (is.na(fg_val)) {
+        return(c((low + high) / 2))
       } else {
         return(c(fg_val))
       }
@@ -66,15 +70,18 @@ make_grid_vect <- function(low,
 # - grid_df: data frame of parameters to sweep
 # outputs:
 # - combined input file and result of each run
-exec_sweep <- function(grid_df){
+exec_sweep <- function(grid_df) {
   for (index in 1:nrow(grid_df)) {
-    if (!quietly)
-      cat(sprintf(
-        "[%s] Calling adjustcarryforward(), run %s of %s\n",
-        Sys.time(),
-        index,
-        nrow(grid_df)
-      ))
+    if (!quietly) {
+      cat(
+        sprintf(
+          "[%s] Calling adjustcarryforward(), run %s of %s\n",
+          Sys.time(),
+          index,
+          nrow(grid_df)
+        )
+      )
+    }
     out <-
       adjustcarryforward(
         subjid,
@@ -97,7 +104,11 @@ exec_sweep <- function(grid_df){
 
     setnames(out, "adjustcarryforward", sprintf("run-%s", index))
     export <-
-      merge(as.data.frame(dm_filt), out, by = "n", all = T)
+      merge(as.data.frame(dm_filt),
+        out,
+        by = "n",
+        all = T
+      )
 
     # Combine into one wide set for simplicity
     if (index == 1) {
@@ -112,80 +123,102 @@ exec_sweep <- function(grid_df){
 
 # Specify parser ----
 
-parser <-
-  ArgumentParser(description = 'CLI driver for carry forward adjustments')
-parser$add_argument(
-  'infile',
-  metavar = 'INFILE',
-  type = 'character',
+parser <- arg_parser("CLI driver for carry forward adjustments")
+parser <- add_argument(parser,
+  "infile",
+  type = "character",
   nargs = 1,
-  help = 'Input file, cleaned by cleangrowth()'
+  help = "Input file, cleaned by cleangrowth()"
 )
-parser$add_argument('--searchtype',
-                    default = 'random',
-                    type = "character",
-                    help = "Type of search to perform: random (default), line-grid, full-grid")
-parser$add_argument('--gridlength',
-                    default = 9,
-                    type = "integer",
-                    help = "Number of steps in grid to search")
-parser$add_argument('--seed',
-                    default = 7,
-                    type = "integer",
-                    help = "Random seed, used only when performing random search")
-parser$add_argument("--param",
-                    default = "none",
-                    type = "character",
-                    help = "CSV to specify which parameters to run full search on, and values to use if not, used only when performing full-grid search")
-parser$add_argument('--quietly',
-                    default = FALSE,
-                    action = 'store_true',
-                    help = 'Verbose debugging info')
-parser$add_argument('--debug',
-                    default = FALSE,
-                    action = 'store_true',
-                    help = 'Produce extra data files for debugging; use w/--outdir')
-parser$add_argument("--maxrecs",
-                    default = 0,
-                    type = "integer",
-                    help = "Limit to specified # recs, default 0 (no limit)")
-parser$add_argument("--outfile",
-                    default = paste0("test_adjustcarryforward_",
-                                     format(Sys.time(), "%m-%d-%Y_%H-%M-%S")),
-                    type = "character",
-                    help = "Output file name, default 'test_adjustcarrforward_DATE_TIME', where DATE is the current system date and time")
+parser <- add_argument(
+  parser,
+  "--searchtype",
+  default = "random",
+  type = "character",
+  help = "Type of search to perform: random (default), line-grid, full-grid"
+)
+parser <- add_argument(
+  parser,
+  "--gridlength",
+  default = 9,
+  type = "integer",
+  help = "Number of steps in grid to search"
+)
+parser <- add_argument(parser,
+  "--seed",
+  default = 7,
+  type = "integer",
+  help = "Random seed, used only when performing random search"
+)
+parser <- add_argument(parser,
+  "--param",
+  default = "none",
+  type = "character",
+  help = "CSV to specify which parameters to run full search on, and values to use if not, used only when performing full-grid search"
+)
+parser <- add_argument(parser,
+  "--quietly",
+  flag = TRUE,
+  help = "Verbose debugging info"
+)
+parser <- add_argument(parser,
+  "--debug",
+  flag = TRUE,
+  help = "Produce extra data files for debugging; use w/--outdir"
+)
+parser <- add_argument(
+  parser,
+  "--maxrecs",
+  default = 0,
+  type = "integer",
+  help = "Limit to specified # recs, default 0 (no limit)"
+)
+parser <- add_argument(parser, "--outfile",
+  default = paste0(
+    "test_adjustcarryforward_",
+    format(Sys.time(), "%m-%d-%Y_%H-%M-%S")
+  ),
+  type = "character",
+  help = "Output file name, default 'test_adjustcarrforward_DATE_TIME', where DATE is the current system date and time"
+)
 
 # Parse arguments for ease ----
 
-args <- parser$parse_args()
+argv <- parse_args(parser)
 
-seed <- args$seed
-searchtype <- args$searchtype
-grid.length <- args$gridlength
-outfile <- args$outfile
-quietly <- args$quietly
-param_choice <- args$param
+seed <- argv$seed
+searchtype <- argv$searchtype
+grid.length <- argv$gridlength
+outfile <- argv$outfile
+quietly <- argv$quietly
+param_choice <- argv$param
 
-if (searchtype == "random"){
+if (searchtype == "random") {
   # if the line search isn't odd, add one so that it includes the midpoint
-  grid.length <- if (grid.length %% 2 == 0){ grid.length + 1 } else { grid.length }
+  grid.length <-
+    if (grid.length %% 2 == 0) {
+      grid.length + 1
+    } else {
+      grid.length
+    }
 }
 
 # Prepare the data ----
 
 # Read in data
-dm <- fread(args$infile)
+dm <- fread(argv$infile)
 setkey(dm, subjid, param, agedays)
 
 # limit dataset for debugging/performance reasons if specified
-if (args$maxrecs > 0) {
-  if (!quietly)
+if (argv$maxrecs > 0) {
+  if (!quietly) {
     cat(sprintf(
       "[%s] Taking max %s recs for debugging\n",
       Sys.time(),
-      args$maxrecs
+      argv$maxrecs
     ))
-  dm_filt <- dm[subjid %in% unique(dm[, subjid])[1:args$maxrecs], ]
+  }
+  dm_filt <- dm[subjid %in% unique(dm[, subjid])[1:argv$maxrecs], ]
 } else {
   dm_filt <- dm
 }
@@ -201,39 +234,43 @@ orig.exclude <- with(dm_filt, clean_value)
 
 # Execute parameter sweep ----
 
-if (!quietly){
-  cat(sprintf(
-    "[%s] Running parameter sweep of adjustcarryforward on cleaned dataset\n",
-    Sys.time()
-  ))
+if (!quietly) {
+  cat(
+    sprintf(
+      "[%s] Running parameter sweep of adjustcarryforward on cleaned dataset\n",
+      Sys.time()
+    )
+  )
 }
 
 # Specify seed, if using random
-if (searchtype == "random"){
+if (searchtype == "random") {
   set.seed(seed)
 }
 
 # Have a data frame of ranges
-param_n <- c("minfactor",
-             "maxfactor",
-             "banddiff",
-             "banddiff_plus",
-             "min_ht.exp_under",
-             "min_ht.exp_over",
-             "max_ht.exp_under",
-             "max_ht.exp_over")
+param_n <- c(
+  "minfactor",
+  "maxfactor",
+  "banddiff",
+  "banddiff_plus",
+  "min_ht.exp_under",
+  "min_ht.exp_over",
+  "max_ht.exp_under",
+  "max_ht.exp_over"
+)
 
 p_range <- data.frame(
   "param" = param_n,
-  low = c(0,0,0,0,0,-1,0,0),
-  high = c(1,4,6,11,4,1,0.66,3)
+  low = c(0, 0, 0, 0, 0, -1, 0, 0),
+  high = c(1, 4, 6, 11, 4, 1, 0.66, 3)
 )
 rownames(p_range) <- p_range$param
 
 # Define the params to test
-if (searchtype == "full-grid"){
+if (searchtype == "full-grid") {
   # specify parameter choices -- default to choosing all
-  if (param_choice != "none"){
+  if (param_choice != "none") {
     param_df <- read.csv(param_choice)
     colnames(param_df) <- c("param", "include", "value")
   } else {
@@ -244,37 +281,47 @@ if (searchtype == "full-grid"){
     )
   }
 
-  if (searchtype == "full-grid"){
-    cat(paste0(
-      "[",Sys.time(),
-      "] Note: due to the search type specified (full-grid), there will be ",
-      grid.length^sum(param_df$include)," runs\n"
-    ))
+  if (searchtype == "full-grid") {
+    cat(
+      paste0(
+        "[",
+        Sys.time(),
+        "] Note: due to the search type specified (full-grid), there will be ",
+        grid.length^sum(param_df$include),
+        " runs\n"
+      )
+    )
   }
 
   # now pass them in one by one
   grid_list <- list()
-  for (i in 1:nrow(param_df)){
+  for (i in 1:nrow(param_df)) {
     grid_list[[param_df$param[i]]] <-
-      make_grid_vect(p_range[param_df$param[i], "low"],
-                     p_range[param_df$param[i], "high"],
-                     grid.length,
-                     searchtype,
-                     as.logical(param_df$include[i]),
-                     as.numeric(param_df$value[i]))
+      make_grid_vect(
+        p_range[param_df$param[i], "low"],
+        p_range[param_df$param[i], "high"],
+        grid.length,
+        searchtype,
+        as.logical(param_df$include[i]),
+        as.numeric(param_df$value[i])
+      )
   }
 
   # make the full grid based on the list
   grid_df <- expand.grid(grid_list)
-} else { # for random and line-grid options
-  grid_df <- as.data.frame(matrix(NA, nrow = grid.length, ncol = nrow(p_range)))
+} else {
+  # for random and line-grid options
+  grid_df <-
+    as.data.frame(matrix(NA, nrow = grid.length, ncol = nrow(p_range)))
   colnames(grid_df) <- p_range$param
-  for (i in 1:ncol(grid_df)){
-    grid_df[,p_range$param[i]] <-
-      make_grid_vect(p_range[p_range$param[i], "low"],
-                     p_range[p_range$param[i], "high"],
-                     grid.length,
-                     searchtype)
+  for (i in 1:ncol(grid_df)) {
+    grid_df[, p_range$param[i]] <-
+      make_grid_vect(
+        p_range[p_range$param[i], "low"],
+        p_range[p_range$param[i], "high"],
+        grid.length,
+        searchtype
+      )
   }
 }
 
@@ -292,7 +339,7 @@ grid <- cbind("run" = 1:nrow(grid_df), grid_df)
 fwrite(grid, paste0(outfile, "_parameters.csv"), row.names = F)
 
 # Any additional debugging output
-if (args$debug) {
+if (argv$debug) {
   if (!quietly) {
     cat(sprintf("[%s] Writing debugging output files\n", Sys.time()))
   }


### PR DESCRIPTION
The previously-used `argparse` library had a Python dependency. This switches the package to use the R-native `argparser`, simplifying environment requirements a touch.

Also updates `README.md` to reference now-included `gcdriver.R` script, and includes minor code reformatting.

This closes https://github.com/mitre/growthcleanr/issues/1.
