### PR TITLE
update GitHub test workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,17 +65,6 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run:
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on =
-          "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,36 +34,10 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key:
-            ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-${{
-            hashFiles('.github/depends.Rds') }}
-          restore-keys:
-            ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
+          extra-packages: any::rcmdcheck
+          needs: check
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,28 +14,25 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-latest, r: "oldrel" }
+          - { os: macOS-latest, r: "release" }
           - { os: windows-latest, r: "release" }
-
-          - { os: macOS-11, r: "release" }
-          - { os: macOS-12, r: "release" }
-
-          - { os: ubuntu-18.04, r: "release" }
-          - { os: ubuntu-20.04, r: "oldrel" }
-          - { os: ubuntu-20.04, r: "release" }
-          - { os: ubuntu-22.04, r: "release" }
+          - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
+          - { os: ubuntu-latest, r: "release" }
+          - { os: ubuntu-latest, r: "oldrel-1" }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-
-      - uses: r-lib/actions/setup-pandoc@v2
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,3 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on: [push, pull_request]
 
 name: R-CMD-check
@@ -21,7 +19,8 @@ jobs:
           - { os: ubuntu-latest, r: "oldrel-1" }
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,22 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'oldrel'}
-          - {os: windows-latest, r: 'release'}
+          - { os: windows-latest, r: "oldrel" }
+          - { os: windows-latest, r: "release" }
 
-          # As of Nov 2021, "macOS-latest" hasn't shifted to 11, so make explicit  
-          - {os: macOS-10.15, r: 'oldrel'}
-          - {os: macOS-10.15, r: 'release'}
-          - {os: macOS-11, r: 'release'}
+          - { os: macOS-11, r: "release" }
+          - { os: macOS-12, r: "release" }
 
-          - {os: ubuntu-18.04, r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-
-          - {os: ubuntu-20.04, r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # Disable as of Nov 2021; failing in GitHub action with rcmdcheck
-          # unavailable, but this is not critical for testing.
-          # - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - { os: ubuntu-18.04, r: "release" }
+          - { os: ubuntu-20.04, r: "oldrel" }
+          - { os: ubuntu-20.04, r: "release" }
+          - { os: ubuntu-22.04, r: "release" }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -37,12 +31,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |
@@ -56,8 +49,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key:
+            ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-${{
+            hashFiles('.github/depends.Rds') }}
+          restore-keys:
+            ${{ matrix.config.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -75,7 +71,9 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run:
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on =
+          "warning", check_dir = "check")
         shell: Rscript {0}
 
       - name: Upload check results


### PR DESCRIPTION
- much simpler, easier to maintain, based on [`usethis::use_github_action_check_standard()`](https://usethis.r-lib.org/reference/github_actions.html) output
- replaces custom definitions of outdated macos/ubuntu versions with "`-latest`"s
- replaces custom dependency check/install config with standard script
- replaces custom package check config with standard script