### PR TITLE
Fix incorrect/missing links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ The rest of this documentation includes:
 
 -   [Quickstart](https://carriedaymont.github.io/growthcleanr/articles/quickstart.html),
     a brief tour of using growthcleanr, including data preparation
--   [Installation](https://carriedaymont.github.io/growthcleanr/articles/usage.html),
+-   [Installation](https://carriedaymont.github.io/growthcleanr/articles/installation.html),
+    options for installing growthcleanr, with notes on specific platforms and source-level
+    installation for developers
+-   [Usage](https://carriedaymont.github.io/growthcleanr/articles/usage.html),
     examples of cleaning data, multiple options, example data
 
 ### Advanced topics:


### PR DESCRIPTION
- bullet for Installation actually linked to and described Usage
- added bullet for Installation that links to and describes Installation