### PR TITLE
T71 keep dates in longwide

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Suggests:
     knitr (>= 1.29),
     rmarkdown (>= 2.3),
     testthat (>= 2.3.2)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/R/utils.R
+++ b/R/utils.R
@@ -204,8 +204,8 @@ longwide <-
            gcr_result = "gcr_result",
            include_all = FALSE,
            inclusion_types = c("Include"),
-           keep_unmatched_data = FALSE,
-           extra_cols = NULL) {
+           extra_cols = NULL,
+           keep_unmatched_data = FALSE) {
     # avoid "no visible binding" warnings
     sex_recoded <- agey <- agem <- HEIGHTCM <- WEIGHTKG <- NULL
     wt <- wt_id <- ht <- ht_id <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,20 +136,46 @@ recode_sex <- function(input_data,
 
 #' Transform data in growthcleanr format into wide structure for BMI calculation
 #'
-#' \code{longwide} transforms data from long to wide format. Ideal for transforming output from growthcleanr::cleangrowth() into a format suitable for growthcleanr::ext_bmiz().
+#' \code{longwide} transforms data from long to wide format. Ideal for
+#' transforming output from growthcleanr::cleangrowth() into a format suitable
+#' for growthcleanr::ext_bmiz().
 #'
-#' @param long_df A data frame to be transformed. Expects columns: id, subjid, sex, agedays, param, measurement, and gcr_result.
+#'
+#' @param extra_cols vector of additional columns to include in the output
+#' @param keep_unmatched boolean to tell whether we shoudl keep observations that do not have a matching height/wieth on that day
+#' # now includes all observations including infants
+#'
+#' @param long_df A data frame to be transformed. Expects columns: id, subjid,
+#' sex, agedays, param, measurement, and gcr_result.
 #' @param id name of observation ID column
 #' @param subjid name of subject ID column
 #' @param sex name of sex descriptor column
 #' @param agedays name of age (in days) descriptor column
 #' @param param name of parameter column to identify each type of measurement
-#' @param measurement name of measurement column containing the actual measurement data
+#' @param measurement name of measurement column containing the actual
+#' measurement data
 #' @param gcr_result name of column of results from growthcleanr::cleangrowth()
-#' @param include_all Determines whether the function keeps all exclusion codes. If TRUE, all exclusion types are kept and the inclusion_types argument is ignored. Defaults to FALSE.
-#' @param inclusion_types Vector indicating which exclusion codes from the cleaning algorithm should be included in the data, given that include_all is FALSE. For all options, see growthcleanr::cleangrowth(). Defaults to c("Include").
+#' @param include_all Determines whether the function keeps all exclusion codes.
+#' If TRUE, all exclusion types are kept and the inclusion_types argument is
+#' ignored. Defaults to FALSE.
+#' @param inclusion_types Vector indicating which exclusion codes from the
+#' cleaning algorithm should be included in the data, given that include_all is
+#' FALSE. For all options, see growthcleanr::cleangrowth(). Defaults to
+#' c("Include").
+#' @param extra_cols Vector of additional columns to include in the output. If
+#' a column C1 differs on agedays matched height and weight values, then include
+#' separate ht_C1 and wt_C1 columns as well as a match_C1 column that gives
+#' booleans indicating where ht_C1 and wt_C1 are the same. If the agedays
+#' matched height and weight columns are identical, then only include a single
+#' version of C1. Defaults to not keeping any extra columns.
+#' @param keep_unmatched_data boolean indicating whether to keep height/weight
+#' observations that do not have a matching weight/height on that day
 #'
-#' @return Returns a data frame transformed from long to wide. Includes only values flagged with indicated inclusion types. Note that, for each subject, heights without corresponding weights for a given age (and vice versa) will be dropped.
+#' @return Returns a data frame transformed from long to wide. Includes only
+#' values flagged with indicated inclusion types. Potentially includes
+#' additional columns if arguments are passed to extra_cols. For each subject,
+#' heights without corresponding weights for a given age (and vice versa) will
+#' be dropped unless keep_unmatched_data is set to TRUE.
 #'
 #' @export
 #' @rawNamespace import(tidyr, except = extract)
@@ -182,101 +208,112 @@ longwide <-
            measurement = "measurement",
            gcr_result = "gcr_result",
            include_all = FALSE,
-           inclusion_types = c("Include")) {
-  # avoid "no visible binding" warnings
-  sex_recoded <- agey <- agem <- HEIGHTCM <- WEIGHTKG <- NULL
-  wt <- wt_id <- ht <- ht_id <- NULL
+           inclusion_types = c("Include"),
+           keep_unmatched_data = FALSE,
+           extra_cols = NULL) {
+    # avoid "no visible binding" warnings
+    sex_recoded <- agey <- agem <- HEIGHTCM <- WEIGHTKG <- NULL
+    wt <- wt_id <- ht <- ht_id <- NULL
 
-  # selects each column with specified / default variable name
-  long_df %>%
-    select(id, subjid, sex, agedays,
-           param, measurement, gcr_result) -> obs_df
+    # check that all needed columns are present, if not, throw an error.
+    if(all(c(id, subjid, sex, agedays, param, measurement, gcr_result,
+             extra_cols) %in% colnames(long_df))) {
+      long_df %>%
+        select(id, subjid, sex, agedays, param, measurement, gcr_result,
+               all_of(extra_cols)) -> obs_df
+    } else {
+      # catch error if any variables were not found
+      stop("not all needed columns were present")
+    }
 
-  # if all columns could be found,
-  # 7 columns will be present in the correct order. Thus, rename
-  if (ncol(obs_df) == 7) {
-    names(obs_df) <- c("id",
-                       "subjid",
-                       "sex",
-                       "agedays",
-                       "param",
-                       "measurement",
-                       "gcr_result")
-  } else {
-    # catch error if any variables were not found
-    stop("not all needed columns were present")
-  }
+    # extract values flagged with indicated inclusion types:
+    if (include_all == TRUE) {
+      obs_df <- obs_df
+    } else if (include_all == FALSE) {
+      obs_df <- obs_df[obs_df$gcr_result %in% inclusion_types,]
+    } else{
+      stop(paste0("include_all is not a logical of length 1. It is a ",
+                  typeof(include_all), " of length ", length(include_all)))
+    }
 
-  # extract values flagged with indicated inclusion types:
-  if (include_all == TRUE) {
-    obs_df <- obs_df
-  } else if (include_all == FALSE) {
-    obs_df <- obs_df[obs_df$gcr_result %in% inclusion_types,]
-  } else{
-    stop(paste0("include_all is not a logical of length 1. It is a ",
-                typeof(include_all), " of length ", length(include_all)))
-  }
+    # calculate age in years
+    obs_df$agey <- round(obs_df$agedays / 365.25, 4)
 
+    # calculate age in months
+    obs_df$agem <- round((obs_df$agey * 12), 4)
 
-  # only include observations at least 24 months old
-  obs_df <- obs_df[obs_df$agedays >= 730, ]
+    # recode sex to expected ext_bmiz() format
+    obs_df <- recode_sex(
+      input_data = obs_df,
+      sourcecol = "sex",
+      sourcem = "0",
+      sourcef = "1",
+      targetcol = "sex_recoded",
+      targetm = 1L,
+      targetf = 2L
+    )
 
-  # calculate age in years
-  obs_df$agey <- round(obs_df$agedays / 365.25, 4)
-
-  # calculate age in months
-  obs_df$agem <- round((obs_df$agey * 12), 4)
-
-  # recode sex to expected ext_bmiz() format
-  obs_df <- recode_sex(
-    input_data = obs_df,
-    sourcecol = "sex",
-    sourcem = "0",
-    sourcef = "1",
-    targetcol = "sex_recoded",
-    targetm = 1L,
-    targetf = 2L
-  )
-
-  obs_df %>%
-    mutate(sex = sex_recoded) %>%
-    mutate(param = as.character(param)) %>%
-    select(subjid, id, agey, agem, agedays, sex, param, measurement) -> clean_df
+    obs_df %>%
+      mutate(sex = sex_recoded) %>%
+      mutate(param = as.character(param)) %>%
+      select(subjid, id, agey, agem, agedays, sex, param, measurement,
+             all_of(extra_cols)) -> clean_df
 
 
-  # check for unique weight and height ids
-  if (any(duplicated(clean_df$id))) {
-    stop("duplicate IDs in long_df")
-  }
+    # check for unique weight and height ids
+    if (any(duplicated(clean_df$id))) {
+      stop("duplicate IDs in long_df")
+    }
 
-  # separate heights and weights using unique ids
-  clean_df %>%
-    pivot_wider(names_from = param, values_from = measurement) -> param_separated
+    # separate heights and weights using unique ids
+    clean_df %>%
+      pivot_wider(names_from = param, values_from = measurement) -> param_separated
 
-  # extract heights and weights attached to ids
-  param_separated %>%
-    filter(!is.na(HEIGHTCM)) %>%
-    filter(is.na(WEIGHTKG)) %>%
-    mutate(ht_id = id) %>%
-    select(-id) %>%
-    select(-WEIGHTKG) -> height
+    # extract heights and weights attached to ids
+    param_separated %>%
+      filter(!is.na(HEIGHTCM)) %>%
+      filter(is.na(WEIGHTKG)) %>% # why this, shouldn't the !is.na height take care of it
+      mutate(ht_id = id) %>%
+      select(-id) %>%
+      select(-WEIGHTKG) -> height
 
-  param_separated %>%
-    filter(is.na(HEIGHTCM)) %>%
-    filter(!is.na(WEIGHTKG)) %>%
-    mutate(wt_id = id) %>%
-    select(-id) %>%
-    select(-HEIGHTCM) -> weight
+    param_separated %>%
+      filter(is.na(HEIGHTCM)) %>%
+      filter(!is.na(WEIGHTKG)) %>%
+      mutate(wt_id = id) %>%
+      select(-id) %>%
+      select(-HEIGHTCM) -> weight
+
+    # join based on subjid, age, and sex, potentially keep unmatched values too
+    wide_df <- merge(height,
+                     weight,
+                     by = c("subjid", "agey", "agem", "agedays", "sex"),
+                     all = keep_unmatched_data) %>%
+      mutate(wt = WEIGHTKG, ht = HEIGHTCM)
 
 
-  # join based on subjid, age, and sex
-  wide_df <- merge(height,
-                   weight,
-                   by = c("subjid", "agey", "agem", "agedays", "sex")) %>%
-    mutate(wt = WEIGHTKG, ht = HEIGHTCM) %>% # rename height and weight
-    select(subjid, agey, agem, sex, wt, wt_id, ht, ht_id, agedays)
+    for(c in extra_cols) {
+      ht_vals <- wide_df[,paste0(c, ".x")]
+      wt_vals <- wide_df[,paste0(c, ".y")]
+      match_vals <- ht_vals == wt_vals
+      match_vals[is.na(ht_vals) & is.na(wt_vals)] = TRUE
 
-  return(wide_df)
+      # If the columns match exactly, then just put a single column with that
+      # name in and drop the other two.
+      if(sum(match_vals, na.rm=TRUE)==length(match_vals)) {
+        wide_df[,c] <- ht_vals
+        wide_df[,c(paste0(c, ".x"), paste0(c, ".y"))] <- list(NULL)
+      } else {
+        wide_df[,paste0("match_", c)] <- match_vals
+        colnames(wide_df)[colnames(wide_df)==paste0(c, ".x")] <- paste0("ht_", c)
+        colnames(wide_df)[colnames(wide_df)==paste0(c, ".y")] <- paste0("wt_", c)
+      }
+    }
+
+    # Drop WEIGHTKG and HEIGHTCM columns since they are in ht and wt
+    wide_df <- wide_df %>% select(-c(HEIGHTCM, WEIGHTKG))
+
+    return(wide_df)
 }
 
 #' Compute BMI using standard formula

--- a/R/utils.R
+++ b/R/utils.R
@@ -299,7 +299,7 @@ longwide <-
         wide_df[,col] <- ht_vals
         wide_df[,c(paste0(col, ".x"), paste0(col, ".y"))] <- list(NULL)
       } else {
-        wide_df[,paste0("match_", c)] <- match_vals
+        wide_df[,paste0("match_", col)] <- match_vals
         colnames(wide_df)[colnames(wide_df)==paste0(col, ".x")] <- paste0("ht_",
                                                                           col)
         colnames(wide_df)[colnames(wide_df)==paste0(col, ".y")] <- paste0("wt_",

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ recode_sex <- function(input_data,
 #' separate ht_C1 and wt_C1 columns as well as a match_C1 column that gives
 #' booleans indicating where ht_C1 and wt_C1 are the same. If the agedays
 #' matched height and weight columns are identical, then only include a single
-#' version of C1. Defaults to not keeping any extra columns.
+#' version of C1. Defaults to empty vector (not keeping any additional columns).
 #' @param keep_unmatched_data boolean indicating whether to keep height/weight
 #' observations that do not have a matching weight/height on that day
 #'
@@ -218,7 +218,7 @@ longwide <-
                all_of(extra_cols)) -> obs_df
     } else {
       # catch error if any variables were not found
-      stop("not all needed columns were present")
+      stop("not all specified columns were present")
     }
 
     # extract values flagged with indicated inclusion types:
@@ -287,21 +287,23 @@ longwide <-
       mutate(wt = WEIGHTKG, ht = HEIGHTCM)
 
 
-    for(c in extra_cols) {
-      ht_vals <- wide_df[,paste0(c, ".x")]
-      wt_vals <- wide_df[,paste0(c, ".y")]
+    for(col in extra_cols) {
+      ht_vals <- wide_df[,paste0(col, ".x")]
+      wt_vals <- wide_df[,paste0(col, ".y")]
       match_vals <- ht_vals == wt_vals
-      match_vals[is.na(ht_vals) & is.na(wt_vals)] = TRUE
+      match_vals[is.na(ht_vals) & is.na(wt_vals)] <- TRUE
 
       # If the columns match exactly, then just put a single column with that
       # name in and drop the other two.
       if(sum(match_vals, na.rm=TRUE)==length(match_vals)) {
-        wide_df[,c] <- ht_vals
-        wide_df[,c(paste0(c, ".x"), paste0(c, ".y"))] <- list(NULL)
+        wide_df[,col] <- ht_vals
+        wide_df[,c(paste0(col, ".x"), paste0(col, ".y"))] <- list(NULL)
       } else {
         wide_df[,paste0("match_", c)] <- match_vals
-        colnames(wide_df)[colnames(wide_df)==paste0(c, ".x")] <- paste0("ht_", c)
-        colnames(wide_df)[colnames(wide_df)==paste0(c, ".y")] <- paste0("wt_", c)
+        colnames(wide_df)[colnames(wide_df)==paste0(col, ".x")] <- paste0("ht_",
+                                                                          col)
+        colnames(wide_df)[colnames(wide_df)==paste0(col, ".y")] <- paste0("wt_",
+                                                                          col)
       }
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,11 +140,6 @@ recode_sex <- function(input_data,
 #' transforming output from growthcleanr::cleangrowth() into a format suitable
 #' for growthcleanr::ext_bmiz().
 #'
-#'
-#' @param extra_cols vector of additional columns to include in the output
-#' @param keep_unmatched boolean to tell whether we shoudl keep observations that do not have a matching height/wieth on that day
-#' # now includes all observations including infants
-#'
 #' @param long_df A data frame to be transformed. Expects columns: id, subjid,
 #' sex, agedays, param, measurement, and gcr_result.
 #' @param id name of observation ID column
@@ -230,7 +225,7 @@ longwide <-
     if (include_all == TRUE) {
       obs_df <- obs_df
     } else if (include_all == FALSE) {
-      obs_df <- obs_df[obs_df$gcr_result %in% inclusion_types,]
+      obs_df <- obs_df[obs_df[,gcr_result] %in% inclusion_types,]
     } else{
       stop(paste0("include_all is not a logical of length 1. It is a ",
                   typeof(include_all), " of length ", length(include_all)))

--- a/man/longwide.Rd
+++ b/man/longwide.Rd
@@ -52,7 +52,7 @@ a column C1 differs on agedays matched height and weight values, then include
 separate ht_C1 and wt_C1 columns as well as a match_C1 column that gives
 booleans indicating where ht_C1 and wt_C1 are the same. If the agedays
 matched height and weight columns are identical, then only include a single
-version of C1. Defaults to not keeping any extra columns.}
+version of C1. Defaults to empty vector (not keeping any additional columns).}
 
 \item{keep_unmatched_data}{boolean indicating whether to keep height/weight
 observations that do not have a matching weight/height on that day}

--- a/man/longwide.Rd
+++ b/man/longwide.Rd
@@ -14,11 +14,14 @@ longwide(
   measurement = "measurement",
   gcr_result = "gcr_result",
   include_all = FALSE,
-  inclusion_types = c("Include")
+  inclusion_types = c("Include"),
+  extra_cols = NULL,
+  keep_unmatched_data = FALSE
 )
 }
 \arguments{
-\item{long_df}{A data frame to be transformed. Expects columns: id, subjid, sex, agedays, param, measurement, and gcr_result.}
+\item{long_df}{A data frame to be transformed. Expects columns: id, subjid,
+sex, agedays, param, measurement, and gcr_result.}
 
 \item{id}{name of observation ID column}
 
@@ -30,19 +33,41 @@ longwide(
 
 \item{param}{name of parameter column to identify each type of measurement}
 
-\item{measurement}{name of measurement column containing the actual measurement data}
+\item{measurement}{name of measurement column containing the actual
+measurement data}
 
 \item{gcr_result}{name of column of results from growthcleanr::cleangrowth()}
 
-\item{include_all}{Determines whether the function keeps all exclusion codes. If TRUE, all exclusion types are kept and the inclusion_types argument is ignored. Defaults to FALSE.}
+\item{include_all}{Determines whether the function keeps all exclusion codes.
+If TRUE, all exclusion types are kept and the inclusion_types argument is
+ignored. Defaults to FALSE.}
 
-\item{inclusion_types}{Vector indicating which exclusion codes from the cleaning algorithm should be included in the data, given that include_all is FALSE. For all options, see growthcleanr::cleangrowth(). Defaults to c("Include").}
+\item{inclusion_types}{Vector indicating which exclusion codes from the
+cleaning algorithm should be included in the data, given that include_all is
+FALSE. For all options, see growthcleanr::cleangrowth(). Defaults to
+c("Include").}
+
+\item{extra_cols}{Vector of additional columns to include in the output. If
+a column C1 differs on agedays matched height and weight values, then include
+separate ht_C1 and wt_C1 columns as well as a match_C1 column that gives
+booleans indicating where ht_C1 and wt_C1 are the same. If the agedays
+matched height and weight columns are identical, then only include a single
+version of C1. Defaults to not keeping any extra columns.}
+
+\item{keep_unmatched_data}{boolean indicating whether to keep height/weight
+observations that do not have a matching weight/height on that day}
 }
 \value{
-Returns a data frame transformed from long to wide. Includes only values flagged with indicated inclusion types. Note that, for each subject, heights without corresponding weights for a given age (and vice versa) will be dropped.
+Returns a data frame transformed from long to wide. Includes only
+values flagged with indicated inclusion types. Potentially includes
+additional columns if arguments are passed to extra_cols. For each subject,
+heights without corresponding weights for a given age (and vice versa) will
+be dropped unless keep_unmatched_data is set to TRUE.
 }
 \description{
-\code{longwide} transforms data from long to wide format. Ideal for transforming output from growthcleanr::cleangrowth() into a format suitable for growthcleanr::ext_bmiz().
+\code{longwide} transforms data from long to wide format. Ideal for
+transforming output from growthcleanr::cleangrowth() into a format suitable
+for growthcleanr::ext_bmiz().
 }
 \examples{
 # Run on a small subset of given data

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -446,8 +446,6 @@ test_that("longwide works as expected when not dropping unmatched values", {
   wide_syn <- longwide(sub_syn, extra_cols = c("r1", "r2"),
                        keep_unmatched_data = TRUE)
 
-  wide_syn2 <- longwide(sub_syn, extra_cols = c("r1", "r2"))
-
   # check for correct number of columns and correct naming; here r2 will not
   # be all matches since there are unmatched heights/weights
   expect_equal(ncol(wide_syn), ncol(sub_syn)+6)
@@ -467,58 +465,6 @@ test_that("longwide works as expected when not dropping unmatched values", {
   ss_ids <- sub_syn$id[sub_syn$gcr_result=="Include"]
 
   expect_equal(sort(obs_ids), sort(ss_ids))
-
-  # spot check that data is correct; add in checks for additional columns
-  set.seed(7)
-  # check height ids
-  ht_sub <-
-    sub_syn[sub_syn$param == "HEIGHTCM" & sub_syn$id %in% obs_ids, ]
-  for (x in ht_sub$id[sample(1:nrow(ht_sub), 20)]) {
-    w_idx <- wide_syn$ht_id == x
-    ht_idx <- ht_sub$id == x
-
-    # since some of the values in the height ID columns are missing, there will
-    # be NA's in "w_idx", which will make subsetting using "w_idx" not work; fix
-    # this by identifying the NA values as FALSE
-    w_idx <- !is.na(w_idx) & w_idx
-
-    # check ages
-    expect_equal(wide_syn$agey[w_idx], round(ht_sub$agedays[ht_idx] / 365.25), 4)
-    expect_equal(wide_syn$agem[w_idx],
-                 round(round(ht_sub$agedays[ht_idx] / 365.25), 4) * 12, 4)
-    expect_equal(wide_syn$agedays[w_idx], ht_sub$agedays[ht_idx])
-
-    # check height
-    expect_equal(wide_syn$ht[w_idx], ht_sub$measurement[ht_idx])
-
-    # check extra columns
-    expect_equal(wide_syn$ht_r1[w_idx], ht_sub$r1[ht_idx])
-    expect_equal(wide_syn$ht_r2[w_idx], ht_sub$r2[ht_idx])
-  }
-
-  # check weight ids
-  wt_sub <-
-    sub_syn[sub_syn$param == "WEIGHTKG" & sub_syn$id %in% obs_ids, ]
-  for (x in wt_sub$id[sample(1:nrow(wt_sub), 20)]) {
-    w_idx <- wide_syn$wt_id == x
-    wt_idx <- wt_sub$id == x
-
-    # again identify the NA values in "w_idx" as FALSE
-    w_idx <- !is.na(w_idx) & w_idx
-
-    # check ages
-    expect_equal(wide_syn$agey[w_idx], round(wt_sub$agedays[wt_idx] / 365.25), 4)
-    expect_equal(wide_syn$agem[w_idx],
-                 round(round(wt_sub$agedays[wt_idx] / 365.25), 4) * 12, 4)
-    expect_equal(wide_syn$agedays[w_idx], wt_sub$agedays[wt_idx])
-
-    # check weight
-    expect_equal(wide_syn$wt[w_idx], wt_sub$measurement[wt_idx])
-
-    # check extra columns
-    expect_equal(wide_syn$wt_r1[w_idx], wt_sub$r1[wt_idx])
-    expect_equal(wide_syn$wt_r2[w_idx], wt_sub$r2[wt_idx])
-  }
 })
 
 test_that("longwide works as expected with other exclusion codes", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -316,6 +316,7 @@ test_that("longwide works as expected with extra columns", {
 
   # add extra columns to sub_syn; one where all values match, and one where they
   # don't
+  set.seed(7)
   sub_syn$r1 <- sample(c("A", "B", "C", "D"), size = nrow(sub_syn),
                        replace = TRUE)
   sub_syn$r2 <- "E"


### PR DESCRIPTION
Closes #71 . Allows for longwide() to keep extra columns and include unmatched data with new options. Tests were updated accordingly.